### PR TITLE
@ 00:15 hs - FIX Syntax error: Bad for loop variable and stat: size in bytes

### DIFF
--- a/spaceman-diff
+++ b/spaceman-diff
@@ -36,8 +36,8 @@ filenameB=`basename $5`
 extB=${filenameB##*.}
 
 # Header row
-sizeA=$(expr $(stat -f %z $fileA) / 1024)
-sizeB=$(expr $(stat -f %z $fileB) / 1024)
+sizeA=$(expr $(stat -c %s $fileA) / 1024)
+sizeB=$(expr $(stat -c %s $fileB) / 1024)
 headerA="OLD: $(basename $1) ($sizeA KB)"
 headerB="NEW: $(basename $5) ($sizeB KB)"
 
@@ -62,7 +62,7 @@ heightA=`echo "$outputA" | wc -l | xargs`
 heightB=`echo "$outputB" | wc -l | xargs`
 max=`echo "$heightA\n$heightB" | sort -nr | head -n1`
 
-for (( i=1; i<=$max; i++ ))
+for i in `seq 1 $max`
 do
   A=$(echo "$outputA" | sed -n ${i}p)
   B=$(echo "$outputB" | sed -n ${i}p)


### PR DESCRIPTION
Hi! in my Bash (versión 4.2.45) test don't pass! :(

```
spaceman-diff: generates ascii image diffs!
  it_shows_help_with_no_argv:                      [PASS]
  it_renders_diff:                                 [FAIL]
    + output='./spaceman-diff test/images/flag.png test/images/flag.png a190ba 100644 test/images/gooder-flag.png 000000 100644'
    + grep OLD:
    + ./spaceman-diff test/images/flag.png test/images/flag.png a190ba 100644 test/images/gooder-flag.png 000000 100644
    stat: no se puede leer la información del sistema de ficheros para «%z»: No existe el fichero o el directorio
    expr: error de sintaxis
    exit code 1
=========================================================
Tests:    2 | Passed:   1 | Failed:   1
```

after my commit:

```
spaceman-diff: generates ascii image diffs!
  it_shows_help_with_no_argv:                      [PASS]
  it_renders_diff:                                 [PASS]
=========================================================
Tests:    2 | Passed:   2 | Failed:   0
```
