### PR TITLE
Output relative paths instead of filenames

### DIFF
--- a/spaceman-diff
+++ b/spaceman-diff
@@ -52,8 +52,8 @@ else
   sizeB=0
 fi
 
-headerA="OLD: $(basename "$1") ($sizeA KB)"
-headerB="NEW: $(basename "$5") ($sizeB KB)"
+headerA="OLD: $1 ($sizeA KB)"
+headerB="NEW: $5 ($sizeB KB)"
 
 lengthA=$(echo $headerA | wc -m | xargs)
 lengthB=$(echo $headerB | wc -m | xargs)

--- a/spaceman-diff-test.sh
+++ b/spaceman-diff-test.sh
@@ -20,8 +20,8 @@ it_renders_diff() {
     test/images/flag.png a190ba 100644 \
     test/images/gooder-flag.png 000000 100644)
 
-  grep -F "OLD: flag.png (84 KB)" < "$output_file"
-  grep -F "NEW: gooder-flag.png (9 KB)" < "$output_file"
+  grep -F "OLD: test/images/flag.png (84 KB)" < "$output_file"
+  grep -F "NEW: test/images/gooder-flag.png (9 KB)" < "$output_file"
 
   rm "$output_file"
 }
@@ -32,8 +32,8 @@ it_works_with_output_filenames_containing_spaces() {
     "test/images/flag.png" a190ba 100644 \
     "test/images/with spaces.png" 000000 100644)
 
-  grep -F 'OLD: flag.png (84 KB)' < "$output_file"
-  grep -F 'NEW: with spaces.png (9 KB)' < "$output_file"
+  grep -F 'OLD: test/images/flag.png (84 KB)' < "$output_file"
+  grep -F 'NEW: test/images/with spaces.png (9 KB)' < "$output_file"
 
   rm "$output_file"
 }
@@ -44,8 +44,8 @@ it_works_with_input_filenames_containing_spaces() {
     "test/images/with spaces.png" a190ba 100644 \
     "test/images/flag.png" 000000 100644)
 
-  grep -F 'OLD: with spaces.png (9 KB)' < "$output_file"
-  grep -F 'NEW: flag.png (84 KB)' < "$output_file"
+  grep -F 'OLD: test/images/with spaces.png (9 KB)' < "$output_file"
+  grep -F 'NEW: test/images/flag.png (84 KB)' < "$output_file"
 
   rm "$output_file"
 }
@@ -56,8 +56,8 @@ it_works_with_small_files() {
     "test/images/gooder-flag.png" a190ba 100644 \
     "test/images/small-image.png" 000000 100644)
 
-  grep -F 'OLD: gooder-flag.png (9 KB)' < "$output_file"
-  grep -F 'NEW: small-image.png (0 KB)' < "$output_file"
+  grep -F 'OLD: test/images/gooder-flag.png (9 KB)' < "$output_file"
+  grep -F 'NEW: test/images/small-image.png (0 KB)' < "$output_file"
 
   rm "$output_file"
 }


### PR DESCRIPTION
This brings spaceman-diff's output closer to `git-diff`'s output; instead of just the filename, we'll now print the relative path to the file instead.

i.e.:

<img width="1440" alt="screenshot" src="https://cloud.githubusercontent.com/assets/2723/13388464/e455bab2-de74-11e5-9a6c-3d7b1fe4b537.png">

Fixes #10.
